### PR TITLE
refactor: update Terraform Cloud to HCP Terraform

### DIFF
--- a/lab-tfc-private-module-registry/terraform-aws-acdmy-webapp/README.md
+++ b/lab-tfc-private-module-registry/terraform-aws-acdmy-webapp/README.md
@@ -1,6 +1,6 @@
 # Terraform Collaboration Private Registry Lab
 
-Terraform code which deploys an s3 webapp for use in the  HashiCorp Academy Terraform Collaboration lab. This module is used to demonstrate TFC/TFE module publishing workflow into the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html).
+Terraform code which deploys an s3 webapp for use in the  HashiCorp Academy Terraform Collaboration lab. This module is used to demonstrate HCP Terraform/TFE module publishing workflow into the [Private Module Registry](https://www.terraform.io/docs/cloud/registry/index.html).
 
 The example module deploys an s3 webapp with an index.html that can be visited for inspection. It is a simple collection of Terraform resources that are grouped into a module.
 

--- a/lab-tfc-private-module-registry/terraform-cloud-oauth/variables.tf
+++ b/lab-tfc-private-module-registry/terraform-cloud-oauth/variables.tf
@@ -1,7 +1,7 @@
 
 variable hostname {
   type        = string
-  description = "The Terraform Cloud/Enterprise hostname to connect to"
+  description = "The HCP Terraform/Enterprise hostname to connect to"
   default     = "app.terraform.io"
 }
 
@@ -12,7 +12,7 @@ variable "oauth_name" {
 
 variable "organization" {
   type = string
-  description = "Terraform Cloud organization"
+  description = "HCP Terraform organization"
 }
 
 variable "gh_pat" {

--- a/lab-tfc-sentinel-cli/sentinel/require-all-resources-from-pmr.sentinel
+++ b/lab-tfc-sentinel-cli/sentinel/require-all-resources-from-pmr.sentinel
@@ -12,9 +12,9 @@ import "tfrun"
 import "strings"
 
 ### Parameters ###
-# The address of the TFC or TFE server
+# The address of the HCP Terraform or TFE server
 param address default "app.terraform.io"
-# The organizations on the TFC or TFE server that modules can some from
+# The organizations on the HCP Terraform or TFE server that modules can some from
 param organizations
 
 # Fnd modules called from root module that are not in the desired PMR


### PR DESCRIPTION
# Pull request
Addressed [Jira ticket ACDMY-872](https://hashicorp.atlassian.net/browse/ACDMY-872?atlOrigin=eyJpIjoiZWFjMmZiNmNmM2FhNGY5MWFlNjQ3MDUwYTQ1Yzc5MDQiLCJwIjoiaiJ9) to update taxonomy of Terraform Cloud

## Description

WHY: Because branding changes have resulting in Terraform Cloud now being called HCP Terraform
WHAT: Text changes only

## Expectation

- [X] Syntax review
- [ ] I don't understand pre-commit validation __HELP__ (You have read the ./contributors.md in the project)
- [ ] Code review && test
- [ ] Something else see How To

