### PR TITLE
Issue 233 - Image Update

### DIFF
--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_firewall" "http-server" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "80"]
+    ports    = ["22", "80", "443"]
   }
 
   // Allow traffic from everywhere to instances with an http-server tag

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,8 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "sudo echo hi > /test.txt"
+  metadata_startup_script = '#! /bin/bash
+  sudo echo hi > /test.txt'
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,10 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "#! /bin/bash \nsudo echo hi > /test.txt"
+  metadata_startup_script = <<<-EOF
+  #! bin/bash
+  sudo echo this-works > test.txt
+  EOF
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_firewall" "http-server" {
 
   allow {
     protocol = "tcp"
-    ports    = ["80"]
+    ports    = ["80", "22"]
   }
 
   // Allow traffic from everywhere to instances with an http-server tag

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "sudo apt update && sudo apt -y install apache2 /nsudo chown -R ubuntu:ubuntu /var/www/html /nchmod +x *.sh /nPLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh"
+  metadata_startup_script = "sudo apt update && sudo apt -y install apache2 /nsudo chmod +x *.sh /nPLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,10 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = <<-EOF
-    #! /bin/bash
-    sudo touch upsilon
-  EOF
+  metadata_startup_script = "sudo echo hi > /test.txt"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -67,8 +67,8 @@ resource "google_compute_instance" "hashicat" {
   }
 
   metadata_startup_script = <<-EOF
-    #! bin/bash
-    sudo echo this-works > test.txt
+  #! bin/bash
+  cd sudo echo this-works > test.txt
   EOF
 
   tags = ["http-server"]

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "sudo apt update && sudo apt -y install apache2"
+  metadata_startup_script = "sudo apt update && sudo apt -y install apache2 /nsudo chown -R ubuntu:ubuntu /var/www/html /nchmod +x *.sh /nPLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -47,7 +47,7 @@ resource "tls_private_key" "ssh-key" {
 
 resource "google_compute_instance" "hashicat" {
   name         = "${var.prefix}-hashicat"
-  zone         = "${var.region}-a"
+  zone         = "${var.region}-b"
   machine_type = var.machine_type
 
   boot_disk {

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "=3.68.0"
+      version = "=4.51.0"
     }
   }
 }

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -23,13 +23,13 @@ resource "google_compute_network" "hashicat" {
 resource "google_compute_subnetwork" "hashicat" {
   name          = "${var.prefix}-subnet"
   region        = var.region
-  network       = google_compute_network.hashicat.self_link
+  network       = google_compute_network.hashicat.id
   ip_cidr_range = var.subnet_prefix
 }
 
 resource "google_compute_firewall" "http-server" {
   name    = "${var.prefix}-default-allow-ssh-http"
-  network = google_compute_network.hashicat.self_link
+  network = google_compute_network.hashicat.id
 
   allow {
     protocol = "tcp"
@@ -57,7 +57,7 @@ resource "google_compute_instance" "hashicat" {
   }
 
   network_interface {
-    subnetwork = google_compute_subnetwork.hashicat.self_link
+    subnetwork = google_compute_subnetwork.hashicat.id
     access_config {
     }
   }

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "sudo apt update && sudo apt -y install apache2 /nsudo chmod +x *.sh /nPLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh"
+  metadata_startup_script = "sudo apt update && sudo apt -y install apache2 \nsudo systemctl start apache2 \ncd /home/ubuntu \nsudo chown -R ubuntu:ubuntu /var/www/html \nsudo chmod +x *.sh \nPLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -67,13 +67,8 @@ resource "google_compute_instance" "hashicat" {
   }
 
   metadata_startup_script = <<-EOF
-    sudo apt update && sudo apt -y install apache2
-    sudo systemctl start apache2
-    sudo chown -R ubuntu:ubuntu /var/www/html
-    chmod +x *.sh
-    PLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh
-    sudo apt -y install cowsay
-    cowsay "Mooooooooooo!"
+    #! /bin/bash
+    touch upsilon
   EOF
 
   tags = ["http-server"]

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,8 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = "#! /bin/bash
-  sudo echo hi > /test.txt"
+  metadata_startup_script = "#! /bin/bash \nsudo echo hi > /test.txt"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_firewall" "http-server" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "80", "443"]
+    ports    = ["22", "80", "8080", "8000"]
   }
 
   // Allow traffic from everywhere to instances with an http-server tag

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -68,7 +68,7 @@ resource "google_compute_instance" "hashicat" {
 
   metadata_startup_script = <<-EOF
     #! /bin/bash
-    touch upsilon
+    sudo touch upsilon
   EOF
 
   tags = ["http-server"]

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,9 +66,9 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = <<<-EOF
-  #! bin/bash
-  sudo echo this-works > test.txt
+  metadata_startup_script = <<-EOF
+    #! bin/bash
+    sudo echo this-works > test.txt
   EOF
 
   tags = ["http-server"]

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,10 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = <<-EOF
-  #! bin/bash
-  cd sudo echo this-works > test.txt
-  EOF
+  metadata_startup_script = "sudo apt update && sudo apt -y install apache2"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -47,7 +47,7 @@ resource "tls_private_key" "ssh-key" {
 
 resource "google_compute_instance" "hashicat" {
   name         = "${var.prefix}-hashicat"
-  zone         = "${var.region}-b"
+  zone         = "${var.region}-a"
   machine_type = var.machine_type
 
   boot_disk {

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_firewall" "http-server" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "80", "8080", "8000"]
+    ports    = ["80"]
   }
 
   // Allow traffic from everywhere to instances with an http-server tag

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,7 +66,7 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = <<SCRIPT
+  metadata_startup_script = <<-EOF
     sudo apt update && sudo apt -y install apache2
     sudo systemctl start apache2
     sudo chown -R ubuntu:ubuntu /var/www/html
@@ -74,7 +74,7 @@ resource "google_compute_instance" "hashicat" {
     PLACEHOLDER=${var.placeholder} WIDTH=${var.width} HEIGHT=${var.height} PREFIX=${var.prefix} ./deploy_app.sh
     sudo apt -y install cowsay
     cowsay "Mooooooooooo!"
-  SCRIPT
+  EOF
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -67,7 +67,7 @@ resource "google_compute_instance" "hashicat" {
   }
 
   metadata_startup_script = <<SCRIPT
-    sudo apt -y install apache2
+    sudo apt update && sudo apt -y install apache2
     sudo systemctl start apache2
     sudo chown -R ubuntu:ubuntu /var/www/html
     chmod +x *.sh

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -66,8 +66,8 @@ resource "google_compute_instance" "hashicat" {
     ssh-keys = "ubuntu:${chomp(tls_private_key.ssh-key.public_key_openssh)} terraform"
   }
 
-  metadata_startup_script = '#! /bin/bash
-  sudo echo hi > /test.txt'
+  metadata_startup_script = "#! /bin/bash
+  sudo echo hi > /test.txt"
 
   tags = ["http-server"]
 

--- a/lab-tfc-hashicat-gcp/main.tf
+++ b/lab-tfc-hashicat-gcp/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "=4.51.0"
+      version = "=3.68.0"
     }
   }
 }

--- a/lab-tfc-hashicat-gcp/outputs.tf
+++ b/lab-tfc-hashicat-gcp/outputs.tf
@@ -3,7 +3,7 @@
 
 # Outputs file
 output "catapp_url" {
-  value = "http://${google_compute_instance.hashicat.network_interface.0.network_ip}"
+  value = "http://${google_compute_instance.hashicat.network_interface.0.access_config.0.nat_ip}"
 }
 
 output "catapp_ip" {

--- a/lab-tfc-hashicat-gcp/outputs.tf
+++ b/lab-tfc-hashicat-gcp/outputs.tf
@@ -3,7 +3,7 @@
 
 # Outputs file
 output "catapp_url" {
-  value = "http://${google_compute_instance.hashicat.network_interface.0.access_config.0.nat_ip}"
+  value = "http://${google_compute_instance.hashicat.network_interface.0.network_ip}"
 }
 
 output "catapp_ip" {

--- a/lab-tfc-hashicat-gcp/variables.tf
+++ b/lab-tfc-hashicat-gcp/variables.tf
@@ -23,7 +23,7 @@ variable "region" {
 
 variable "zone" {
   description = "The zone where the resources are created."
-  default     = "us-central1-a" 
+  default     = "us-central1-b" 
 }
 
 variable "subnet_prefix" {

--- a/lab-tfc-hashicat-gcp/variables.tf
+++ b/lab-tfc-hashicat-gcp/variables.tf
@@ -24,7 +24,7 @@ variable "region" {
 
 variable "zone" {
   description = "The zone where the resources are created."
-  default     = "us-central1-b" 
+  default     = "us-central1-b"
 }
 
 variable "subnet_prefix" {

--- a/lab-tfc-hashicat-gcp/variables.tf
+++ b/lab-tfc-hashicat-gcp/variables.tf
@@ -23,7 +23,7 @@ variable "region" {
 
 variable "zone" {
   description = "The zone where the resources are created."
-  default     = "us-central1-b"
+  default     = "us-central1-a" 
 }
 
 variable "subnet_prefix" {

--- a/lab-tfc-hashicat-gcp/variables.tf
+++ b/lab-tfc-hashicat-gcp/variables.tf
@@ -14,6 +14,7 @@ variable "project" {
 
 variable "prefix" {
   description = "This prefix will be included in the name of some resources. You can use your own name or any other short string here."
+  default     = "instruqt"
 }
 
 variable "region" {


### PR DESCRIPTION
# Pull request


## Related Issue

tag the issue number with `#number` syntax;
__issue__ #233

## Description
WHAT: Updating the startup script to successfully start the Apache2 server and show the cat app homepage
WHY: The tfc-workflows-api lesson in enablement-terraform-instruqt currently fails to show a webpage at the external IP that is generated during the lab.

## Expectation

please check all the relevant components;

- [X] Syntax review
- [ ] I don't understand pre-commit validation __HELP__ (You have read the ./contributors.md in the project)
- [X] Code review && test
- [ ] Something else see How To


You should be able to test this here - https://play.instruqt.com/manage/HashiCorp-EA/tracks/dev-tfc-workflows-api