### PR TITLE
Add in stable infra for Terramino game on AWS

### DIFF
--- a/demo-terramino/bootstrap.tftpl
+++ b/demo-terramino/bootstrap.tftpl
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Install necessary dependencies
+sudo DEBIAN_FRONTEND=noninteractive apt-get -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" dist-upgrade
+sudo apt-get update
+sudo apt-get -y -qq install curl wget git vim apt-transport-https ca-certificates
+sudo apt -y -qq install golang-go
+
+# Setup sudo to allow no-password sudo for your group and adding your user
+sudo groupadd -r ${department}
+sudo useradd -m -s /bin/bash ${name}
+sudo usermod -a -G ${department} ${name}
+sudo cp /etc/sudoers /etc/sudoers.orig
+echo "${name} ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/${name}
+
+# Create GOPATH for your user & download the webapp from github
+sudo -H -i -u ${name} -- env bash << EOF
+cd /home/${name}
+export GOROOT=/usr/lib/go
+export GOPATH=/home/${name}/go
+export PATH=$PATH:$GOROOT/bin:$GOPATH/bin
+git clone https://github.com/hashicorp/learn-go-webapp-demo.git
+cd learn-go-webapp-demo
+go run webapp.go
+EOF

--- a/demo-terramino/data.tf
+++ b/demo-terramino/data.tf
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}

--- a/demo-terramino/main.tf
+++ b/demo-terramino/main.tf
@@ -1,0 +1,23 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+locals {
+  bootstrap_values = {
+    department = var.department,
+    name       = var.name,
+  }
+}
+
+resource "aws_instance" "terramino" {
+  ami                         = data.aws_ami.ubuntu.id
+  instance_type               = var.instance_type
+  associate_public_ip_address = true
+  subnet_id                   = aws_subnet.terramino.id
+  vpc_security_group_ids      = [aws_security_group.terramino.id]
+
+  user_data = templatefile("./bootstrap.tftpl", local.bootstrap_values)
+
+  tags = {
+    Name = "${var.prefix}-terramino-instance"
+  }
+}

--- a/demo-terramino/network.tf
+++ b/demo-terramino/network.tf
@@ -1,0 +1,78 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+resource "aws_vpc" "terramino" {
+  cidr_block           = var.address_space
+  enable_dns_hostnames = true
+
+  tags = {
+    name        = "${var.prefix}-vpc-${var.region}"
+    environment = "Production"
+  }
+}
+
+resource "aws_subnet" "terramino" {
+  vpc_id     = aws_vpc.terramino.id
+  cidr_block = var.subnet_prefix
+
+  tags = {
+    name = "${var.prefix}-subnet"
+  }
+}
+
+resource "aws_security_group" "terramino" {
+  name = "${var.prefix}-security-group"
+
+  vpc_id = aws_vpc.terramino.id
+
+  ingress {
+    from_port   = 8080
+    to_port     = 8080
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+    prefix_list_ids = []
+  }
+
+  tags = {
+    Name = "${var.prefix}-security-group"
+  }
+}
+
+resource "aws_internet_gateway" "terramino" {
+  vpc_id = aws_vpc.terramino.id
+
+  tags = {
+    Name = "${var.prefix}-internet-gateway"
+  }
+}
+
+resource "aws_route_table" "terramino" {
+  vpc_id = aws_vpc.terramino.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.terramino.id
+  }
+}
+
+resource "aws_route_table_association" "terramino" {
+  subnet_id      = aws_subnet.terramino.id
+  route_table_id = aws_route_table.terramino.id
+}
+
+resource "aws_eip" "terramino" {
+  instance = aws_instance.terramino.id
+  domain   = "vpc"
+}
+
+resource "aws_eip_association" "terramino" {
+  instance_id   = aws_instance.terramino.id
+  allocation_id = aws_eip.terramino.id
+}

--- a/demo-terramino/outputs.tf
+++ b/demo-terramino/outputs.tf
@@ -1,0 +1,10 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+output "catapp_url" {
+  value = "http://${aws_eip.terramino.public_dns}:8080"
+}
+
+output "catapp_ip" {
+  value = "http://${aws_eip.terramino.public_ip}:8080"
+}

--- a/demo-terramino/terraform.tf
+++ b/demo-terramino/terraform.tf
@@ -1,0 +1,20 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.6"
+    }
+  }
+
+  required_version = "~> 1.2"
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/demo-terramino/variables.tf
+++ b/demo-terramino/variables.tf
@@ -1,0 +1,37 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+variable "prefix" {
+  description = "This prefix will be included in the name of most resources."
+  default     = "academy"
+}
+
+variable "region" {
+  description = "The region where the resources are created."
+  default     = "us-east-1"
+}
+
+variable "address_space" {
+  description = "The address space that is used by the virtual network. You can supply more than one address space. Changing this forces a new resource to be created."
+  default     = "10.0.0.0/16"
+}
+
+variable "subnet_prefix" {
+  description = "The address prefix to use for the subnet."
+  default     = "10.0.10.0/24"
+}
+
+variable "instance_type" {
+  description = "Specifies the AWS instance type."
+  default     = "t2.micro"
+}
+
+variable "name" {
+  description = "The user account for the compute instance"
+  default     = "terraform"
+}
+
+variable "department" {
+  description = "The organization the user belongs to: dev, prod, qa"
+  default     = "prod"
+}


### PR DESCRIPTION
# Pull request

## Description

Adds in code for a stable ( i.e. working as-is ) configuration for a Tetris-like game that can be provisioned without any user interaction.

The code in `demo-terramino` works as-is and does not require any user interaction. Can be fully deployed with `terraform init && terraform apply -auto-approve` through automation.