### PR TITLE
Pins AWS Provider Version

### DIFF
--- a/demo-terramino/outputs.tf
+++ b/demo-terramino/outputs.tf
@@ -4,7 +4,3 @@
 output "catapp_url" {
   value = "http://${aws_eip.terramino.public_dns}:8080"
 }
-
-output "catapp_ip" {
-  value = "http://${aws_eip.terramino.public_ip}:8080"
-}

--- a/demo-terramino/terraform.tf
+++ b/demo-terramino/terraform.tf
@@ -5,6 +5,7 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
+      version = "5.82.2"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
# Pull request


## Related Issue

- Pins AWS Provider to version `5.82.2` ( verified working )
- Removes extra output ( IP vs DNS name )